### PR TITLE
Use container name expected by tilt

### DIFF
--- a/runtime-sdk/config/default/deployment.yaml
+++ b/runtime-sdk/config/default/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         - command:
             - /manager
           image: controller:latest
-          name: test-runtime-sdk
+          name: manager
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/runtime-sdk/config/default/deployment_image_patch.yaml
+++ b/runtime-sdk/config/default/deployment_image_patch.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
         - image: gcr.io/k8s-staging-extension-config/test-runtime-sdk:main
-          name: test-runtime-sdk
+          name: manager

--- a/runtime-sdk/config/default/deployment_webhook.yaml
+++ b/runtime-sdk/config/default/deployment_webhook.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-        - name: test-runtime-sdk
+        - name: manager
           ports:
             - containerPort: 9443
               name: webhook-server


### PR DESCRIPTION
Update the container name to the one tilt assumes when building providers.